### PR TITLE
Update 'enabled' setting for Prometheus Exporters due to new default settings

### DIFF
--- a/docker-compose-influxdb-jaeger.yml
+++ b/docker-compose-influxdb-jaeger.yml
@@ -34,7 +34,6 @@ services:
     image: inspectit/inspectit-ocelot-eum-server:${INSPECTIT_OCELOT_VERSION}
     container_name: ocelot-eum-server
     environment:
-      - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_INFLUX_DATABASE=inspectit_eum
       - INSPECTIT_EUM_SERVER_EXPORTERS_TRACING_JAEGER_GRPC=jaeger:14250
@@ -55,7 +54,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=config-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -78,7 +76,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=discovery-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -102,7 +99,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=customers-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -127,7 +123,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=visits-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -152,7 +147,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=vets-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -177,7 +171,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=api-gateway
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:

--- a/docker-compose-influxdb-zipkin.yml
+++ b/docker-compose-influxdb-zipkin.yml
@@ -34,7 +34,6 @@ services:
     image: inspectit/inspectit-ocelot-eum-server:${INSPECTIT_OCELOT_VERSION}
     container_name: ocelot-eum-server
     environment:
-      - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_INFLUX_DATABASE=inspectit_eum
     deploy:
@@ -54,7 +53,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=config-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:
@@ -77,7 +75,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=discovery-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:
@@ -101,7 +98,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=customers-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:
@@ -126,7 +122,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=visits-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:
@@ -151,7 +146,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=vets-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:
@@ -176,7 +170,6 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=api-gateway
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
-      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=false
       - INSPECTIT_EXPORTERS_METRICS_INFLUX_URL=http://influxdb:8086
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://zipkin:9411/api/v2/spans
     deploy:

--- a/docker-compose-prometheus-jaeger.yml
+++ b/docker-compose-prometheus-jaeger.yml
@@ -35,6 +35,7 @@ services:
     container_name: ocelot-eum-server
     hostname: ocelot-eum-server
     environment:
+      - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_PROMETHEUS_PORT=9097
       - INSPECTIT_EUM_SERVER_EXPORTERS_METRICS_PROMETHEUS_HOST=0.0.0.0
       - INSPECTIT_EUM_SERVER_EXPORTERS_TRACING_JAEGER_GRPC=jaeger:14250
@@ -57,6 +58,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=config-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9096
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -80,6 +82,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=discovery-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9095
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -104,6 +107,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=customers-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9091
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -129,6 +133,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=visits-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9092
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -154,6 +159,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=vets-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9093
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:
@@ -179,6 +185,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=api-gateway
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9094
       - INSPECTIT_EXPORTERS_TRACING_JAEGER_URL=http://jaeger:14268/api/traces
     deploy:

--- a/docker-compose-wavefront-zipkin.yml
+++ b/docker-compose-wavefront-zipkin.yml
@@ -37,6 +37,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=config-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9096
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:
@@ -61,6 +62,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=discovery-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9095
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:
@@ -86,6 +88,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=customers-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9091
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:
@@ -112,6 +115,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=visits-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9092
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:
@@ -138,6 +142,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=vets-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9093
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:
@@ -164,6 +169,7 @@ services:
     environment:
       - INSPECTIT_SERVICE_NAME=api-gateway
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
+      - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_ENABLED=ENABLED
       - INSPECTIT_EXPORTERS_METRICS_PROMETHEUS_PORT=9094
       - INSPECTIT_EXPORTERS_TRACING_ZIPKIN_URL=http://wfproxy:9411/api/v2/spans
     deploy:


### PR DESCRIPTION
Since https://github.com/inspectIT/inspectit-ocelot/pull/1303 the prometheus exporters are disabled by default. 
Therefore, in the demo some settings needed to be updated (removing unnecessary disabling, adding enabling where necessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot-demo/4)
<!-- Reviewable:end -->
