### PR TITLE
Fixes #22 - Adds missing influx datasource to grafana provisioning

### DIFF
--- a/grafana/provisioning/influxdb/datasources/influxdb.yml
+++ b/grafana/provisioning/influxdb/datasources/influxdb.yml
@@ -27,3 +27,21 @@ datasources:
     type: loki
     access: proxy
     url: http://loki:3100
+  - orgId: 1
+    name: LocalInflux
+    type: influxdb
+    typeName: InfluxDB
+    typeLogoUrl: public/app/plugins/datasource/influxdb/img/influxdb_logo.svg
+    access: proxy
+    url: http://influxdb:8086
+    database: inspectit
+    readOnly: false
+  - orgId: 1
+    name: InfluxDB-EUM
+    type: influxdb
+    typeName: InfluxDB
+    typeLogoUrl: public/app/plugins/datasource/influxdb/img/influxdb_logo.svg
+    access: proxy
+    url: http://influxdb:8086
+    database: inspectit_eum
+    readOnly: false

--- a/grafana/provisioning/influxdb/datasources/influxdb.yml
+++ b/grafana/provisioning/influxdb/datasources/influxdb.yml
@@ -10,18 +10,6 @@ datasources:
       tracesToLogs:
         datasourceUid: K1XkGKR4z
   - orgId: 1
-    version: 1
-    name: LocalPrometheus
-    type: prometheus
-    access: proxy
-    url: http://prometheus:9090
-    jsonData:
-      timeInterval: 15s
-    secureJsonData:
-      tlsCACert: $LOCALPROMETHEUS_TLSCACERT
-      tlsClientCert: $LOCALPROMETHEUS_TLSCLIENTCERT
-      tlsClientKey: $LOCALPROMETHEUS_TLSCLIENTKEY
-  - orgId: 1
     version: 3
     name: Loki
     type: loki


### PR DESCRIPTION
Closes #22

![image](https://user-images.githubusercontent.com/33718194/214910424-731b07af-a58b-456c-b0d1-87257a72cb15.png)

I could not find the exact point when the data sources went missing but [here](https://github.com/heiko-holz/inspectit-ocelot-demo/blob/feature/feat-1-add-k8s-demo/spring-petclinic-docker-demo/grafana/provisioning/influxdb/datasources/influxdb.yml) they were still present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot-demo/23)
<!-- Reviewable:end -->
